### PR TITLE
feat(activation): add backward() function to ReLu class

### DIFF
--- a/activation/relu.py
+++ b/activation/relu.py
@@ -10,3 +10,6 @@ class ReLu():
             return np.max(0, output)
         elif isinstance(output, np.ndarray):
             return np.maximum(np.zeros(output.size), output)
+    
+    def backward(self, net):
+        return 1 if net > 0 else 0


### PR DESCRIPTION
Add backward() function to ReLu class in relu.py file. backward()
function takes one parameter which is net. net parameter is the
derivative of the previous step, in other words, the net value of the
forward version of the relevant layer of the network., it should be
one-dimensional ndarray with one or more size.

Refs ANN-11