### PR TITLE
fix(loss): fix division by zero and log(0) error

### DIFF
--- a/loss/binary_cross_entropy.py
+++ b/loss/binary_cross_entropy.py
@@ -6,7 +6,14 @@ class BinaryCrossEntropy():
         return
     
     def calculate(self, y, yhat):
-        return -((y * np.log(yhat)) + ((1-y) * np.log(1-yhat)))
+        if not isinstance(y, np.ndarray): y = np.array(y)
+        if not isinstance(yhat, np.ndarray): yhat = np.array(yhat)
+        
+        clipped_yhat = np.clip(yhat, 1e-7, 1 - 1e-7)
+        
+        return -((y * np.log(clipped_yhat)) + ((1-y) * np.log(1-clipped_yhat)))
     
     def backward(self, y, yhat):
-        return (-y/yhat) + ((1-y) / (1-yhat))
+        clipped_yhat = np.clip(yhat, 1e-7, 1 - 1e-7)
+        
+        return (-y/clipped_yhat) + ((1-y) / (1-clipped_yhat))


### PR DESCRIPTION
calculate() and backward() function produces errors which are division
by zero and log(0) error.

This commit fixs this problems with numpy clip() function. Solve the
problem by subjecting  arguments of functions with error to numpy
clip() function.